### PR TITLE
Anthonyaue/remove cr

### DIFF
--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -38,7 +38,11 @@ class PosixReadableFile : public ReadableFile {
   util::Status status() const { return status_; }
 
   bool ReadLine(std::string *line) {
-    return static_cast<bool>(std::getline(*is_, *line));
+      bool ret = static_cast<bool>(std::getline(*is_, *line));
+      // Now that we're in binary mode, we have to throw out carriage return if present
+      if(*is_ && !line->empty() && line->back() == is_->widen('\r'))
+          line->pop_back();
+      return ret;
   }
 
   bool ReadAll(std::string *line) {

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -38,11 +38,11 @@ class PosixReadableFile : public ReadableFile {
   util::Status status() const { return status_; }
 
   bool ReadLine(std::string *line) {
-      bool ret = static_cast<bool>(std::getline(*is_, *line));
-      // Now that we're in binary mode, we have to throw out carriage return if present
-      if(*is_ && !line->empty() && line->back() == is_->widen('\r'))
-          line->pop_back();
-      return ret;
+    bool ret = static_cast<bool>(std::getline(*is_, *line));
+    // Now that we're in binary mode, we have to throw out carriage return if present
+    if(*is_ && !line->empty() && line->back() == is_->widen('\r'))
+        line->pop_back();
+    return ret;
   }
 
   bool ReadAll(std::string *line) {

--- a/test.bat
+++ b/test.bat
@@ -8,11 +8,12 @@ set PATH=c:\Program Files\Git\usr\bin;c:\MinGW\bin;%PATH%
 set CURRENT_PATH=%~dp0
 set LIBRARY_PATH=%CURRENT_PATH%build\root
 
+powershell -command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('https://github.com/google/protobuf/releases/download/v%PROTOBUF_VERSION%/protobuf-cpp-%PROTOBUF_VERSION%.zip', '.\protobuf-cpp-%PROTOBUF_VERSION%.zip') }"
+
 mkdir build
 cd build
 
-curl -O -L https://github.com/google/protobuf/releases/download/v%PROTOBUF_VERSION%/protobuf-cpp-%PROTOBUF_VERSION%.zip
-unzip protobuf-cpp-%PROTOBUF_VERSION%.zip
+unzip ..\protobuf-cpp-%PROTOBUF_VERSION%.zip
 cd protobuf-%PROTOBUF_VERSION%\cmake
 cmake . -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PATH% || goto :error
 cmake --build . --config Release --target install || goto :error

--- a/test_minexport.bat
+++ b/test_minexport.bat
@@ -16,12 +16,15 @@ set PATH=c:\Program Files\Git\usr\bin;c:\MinGW\bin;%PATH%
 set CURRENT_PATH=%~dp0
 set LIBRARY_PATH=%CURRENT_PATH%build\root
 
+rename CMakeLists.txt CMakeLists.txt.stock
+rename src\CMakeLists.txt CMakeLists.txt.stock
+copy CMakeLists_minexport.txt CMakeLists.txt
+copy src\CMakeLists_minexport.txt src\CMakeLists.txt
+
 mkdir build
-copy protobuf-cpp-%PROTOBUF_VERSION%.zip build
 cd build
 
-rem curl -O -L https://github.com/google/protobuf/releases/download/v%PROTOBUF_VERSION%/protobuf-cpp-%PROTOBUF_VERSION%.zip
-unzip protobuf-cpp-%PROTOBUF_VERSION%.zip
+unzip ..\protobuf-cpp-%PROTOBUF_VERSION%.zip
 cd protobuf-%PROTOBUF_VERSION%\cmake
 cmake . -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PATH% -DBUILD_SHARED_LIBS=true -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -DCMAKE_SYSTEM_VERSION=8.1 || goto :error
 rem cmake . -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PATH% || goto :error


### PR DESCRIPTION
Gary's change to read files as binary (to work around ^Z terminating input) had the negative side effect that when we read Windows-encoded (CRLR) files, we end up with an extra carriage return on each line. This pulls that off with some code from Frank.