### PR TITLE
Install sentencepiece.pc from CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ configure_file("${PROJECT_SOURCE_DIR}/config.h.in" "config.h")
 configure_file("${PROJECT_SOURCE_DIR}/sentencepiece.pc.in" "sentencepiece.pc" @ONLY)
 
 if (NOT MSVC)
-  install(FILES "${CMAKE_BINARY_DIR}/sentencepiece.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sentencepiece.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 include_directories("." ${CMAKE_SOURCE_DIR} ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
sentencepiece.pc should be installed from CMAKE_CURRENT_BINARY_DIR, not CMAKE_BINARY_DIR, to support being included from other projects