### PR TITLE
Fix regex_error exceptions in regex_search on VSC compiled binaries

### DIFF
--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -15,8 +15,8 @@
 #ifndef NORMALIZER_CASE_ENCODER_H_
 #define NORMALIZER_CASE_ENCODER_H_
 
-// Reduce liklihood of regex_error exceptions on VSC compiled bins by increasing the 
-// library specific stack size and complexity limits for regex on VSC
+// Reduce liklihood of regex_error exceptions on VSC compiled bins by increasing
+// library specific stack size and complexity limits
 #ifdef _MSC_VER
 #define _REGEX_MAX_STACK_COUNT 200000
 #define _REGEX_MAX_COMPLEXITY_COUNT 0

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -15,6 +15,8 @@
 #ifndef NORMALIZER_CASE_ENCODER_H_
 #define NORMALIZER_CASE_ENCODER_H_
 
+// Reduce liklihood of regex_error exceptions on VSC compiled bins by increasing the 
+// library specific stack size and complexity limits for regex on VSC
 #ifdef _MSC_VER
 #define _REGEX_MAX_STACK_COUNT 200000
 #define _REGEX_MAX_COMPLEXITY_COUNT 0
@@ -215,7 +217,7 @@ public:
         }
       }
     } catch (std::regex_error&) {
-        LOG(WARNING) << "Regex error encountered in case encoding; rejecting sentence";
+        LOG(WARNING) << "regex_error with unicode case encoding; rejecting sentence";
         return;
     }
 

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -215,6 +215,7 @@ public:
         }
       }
     } catch (std::regex_error&) {
+        LOG(WARNING) << "Regex error encountered in case encoding; rejecting sentence";
         return;
     }
 


### PR DESCRIPTION
On windows with VSC compiled binaries, instances of std::regex_error exception were observed being thrown from the regex_search function. The root cause is that the library regex implementation is recursive, and can blow past the call stack and regex complexity limits implicit to the library on larger inputs. As a solution to this problem, this fix

1. Tries to prevent normalization failure in case an error is seen by catching and handling this exception.
2. Prevents the exception from being raised by increasing the stack size and complexity limits for regex on VSC compiled binaries.