### PR TITLE
Fix Surface String to Token Mappings for Case Encoding

### DIFF
--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -67,7 +67,7 @@ public:
 class UpperCaseEncoder : public CaseEncoder {
 private:
   std::string buffer_;
-  std::vector<std::pair<absl::string_view, int> > buffer_lst_;
+  std::vector<std::pair<absl::string_view, int> > buffer_queue_;
   int dump_buffer_from_ = -1;
 
   std::string signature_;
@@ -84,13 +84,13 @@ public:
 
   std::pair<absl::string_view, int> normalizePrefix(absl::string_view orig_input) {
 
-    if((dump_buffer_from_ >= 0) && (dump_buffer_from_ < buffer_lst_.size())) {
-      return buffer_lst_[dump_buffer_from_++];
+    if((dump_buffer_from_ >= 0) && (dump_buffer_from_ < buffer_queue_.size())) {
+      return buffer_queue_[dump_buffer_from_++];
     }
 
     if(dump_buffer_from_ > -1) {
       dump_buffer_from_ = -1;
-      buffer_lst_.clear();
+      buffer_queue_.clear();
       return {nullptr, 0};
     }
 
@@ -111,7 +111,7 @@ public:
       auto cur_buf_last = buffer_.size();
       buffer_.append(sp.data(), sp.size());
       auto tmp_str = absl::string_view(buffer_).substr(cur_buf_last, sp.size());
-      buffer_lst_.push_back({tmp_str, override_consumed == -1 ? p.second : override_consumed});
+      buffer_queue_.push_back({tmp_str, override_consumed == -1 ? p.second : override_consumed});
     };
 
     auto isUpper  = [=](absl::string_view sp) { return sp[0] == cUppercase;   };
@@ -120,7 +120,7 @@ public:
 
     if(state_ == 0) {
       buffer_.clear();
-      buffer_lst_.clear();
+      buffer_queue_.clear();
       offset = 0;
     }
 

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -85,8 +85,7 @@ public:
   std::pair<absl::string_view, int> normalizePrefix(absl::string_view orig_input) {
 
     if((dump_buffer_from_ >= 0) && (dump_buffer_from_ < buffer_lst_.size())) {
-      dump_buffer_from_++;
-      return buffer_lst_[dump_buffer_from_ - 1];
+      return buffer_lst_[dump_buffer_from_++];
     }
 
     if(dump_buffer_from_ > -1) {
@@ -108,11 +107,11 @@ public:
       return {{nullptr, 0}, 0};
     };
 
-    auto buffer = [this, p](absl::string_view sp) {
+    auto buffer = [this, p](absl::string_view sp, int override_consumed = -1) {
       auto cur_buf_last = buffer_.size();
       buffer_.append(sp.data(), sp.size());
       auto tmp_str = absl::string_view(buffer_).substr(cur_buf_last, sp.size());
-      buffer_lst_.push_back({tmp_str, p.second});
+      buffer_lst_.push_back({tmp_str, override_consumed == -1 ? p.second : override_consumed});
     };
 
     auto isUpper  = [=](absl::string_view sp) { return sp[0] == cUppercase;   };
@@ -163,12 +162,7 @@ public:
         signature_.append(sp.size(), 'p');
       } else if(state_ == 2 && !isSpace(sp)) {
         spans_ = 0;
-        // TODO: Currently TmattL => L gets mapped to T, whereas, ideally t should be mapped to T, and L should be ""
-        buffer_ += cLowercase;
-        auto lastbuf = buffer_lst_[buffer_lst_.size() - 1];
-        buffer_lst_[buffer_lst_.size() - 1]
-            = {absl::string_view(lastbuf.first.data(), lastbuf.first.size() + 1),
-               lastbuf.second};
+        buffer(std::string(1, cLowercase), 0);
         signature_.append("L");
         signature_.append(sp.size(), 'l');
       } else if(isSpace(sp)) {

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -99,7 +99,7 @@ public:
     auto sp = p.first;
     int consumed = p.second;
 
-    bool last = input.size() == (size_t)consumed;
+    bool last = input.size() == (size_t)consumed + offset;
     decltype(p) ret;
 
     auto null = [this](int consumed) -> std::pair<absl::string_view, int> {

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -151,7 +151,7 @@ public:
 
       if(last) {
         dump_buffer_from_ = 0;
-        return this->normalizePrefix(orig_input);
+        return null(0);
       }
     } else {
       if(isPunct(sp)) {
@@ -180,7 +180,7 @@ public:
         offset = 0;
         dump_buffer_from_ = 0;
         state_ = 0;
-        return this->normalizePrefix(orig_input);
+        return null(0);
       } else {
         p.first = sp;
       }

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -125,8 +125,9 @@ public:
     if(isUpper(sp)) {
       if(state_ == 0) {
         buffer(sp);
-        
         buffer_[0] = cTitlecase;
+        buffer_queue_.front().first[0] = cTitlecase;
+        
         state_ = 1;
         ret = null(consumed);
         
@@ -139,7 +140,7 @@ public:
         
         sp.remove_prefix(1);
         buffer(sp);
-
+        buffer_queue_.front().first[0] = cUppercase;
         buffer_[0] = cUppercase;
         state_ = 2;
         ret = null(consumed);

--- a/src/case_encoder.h
+++ b/src/case_encoder.h
@@ -67,11 +67,10 @@ public:
 class UpperCaseEncoder : public CaseEncoder {
 private:
   std::string buffer_;
-  std::vector<std::pair<absl::string_view, int> > buffer_queue_;
-  int dump_buffer_from_ = -1;
-
   std::string signature_;
   int offset = 0;
+  std::vector<std::pair<std::string, int> > buffer_queue_;
+  int dump_buffer_from_ = -1;
   
   int state_{0};
   size_t spans_{0};
@@ -83,7 +82,6 @@ public:
   : removeExtraWhiteSpace_(removeExtraWhiteSpace) {}
 
   std::pair<absl::string_view, int> normalizePrefix(absl::string_view orig_input) {
-
     if((dump_buffer_from_ >= 0) && (dump_buffer_from_ < buffer_queue_.size())) {
       return buffer_queue_[dump_buffer_from_++];
     }
@@ -99,7 +97,7 @@ public:
     auto sp = p.first;
     int consumed = p.second;
 
-    bool last = input.size() == (size_t)consumed + offset;
+    bool last = input.size() == (size_t)consumed;
     decltype(p) ret;
 
     auto null = [this](int consumed) -> std::pair<absl::string_view, int> {
@@ -110,7 +108,7 @@ public:
     auto buffer = [this, p](absl::string_view sp, int override_consumed = -1) {
       auto cur_buf_last = buffer_.size();
       buffer_.append(sp.data(), sp.size());
-      auto tmp_str = absl::string_view(buffer_).substr(cur_buf_last, sp.size());
+      auto tmp_str = std::string(buffer_).substr(cur_buf_last, sp.size());
       buffer_queue_.push_back({tmp_str, override_consumed == -1 ? p.second : override_consumed});
     };
 

--- a/src/sentencepiece_processor.cc
+++ b/src/sentencepiece_processor.cc
@@ -621,30 +621,13 @@ util::Status SentencePieceProcessor::Decode(
     *text = normalized;
     std::map<int, int> orig_to_norm;
     for(int i = 0; i < norm_to_orig.size(); i++) {
-      std::cout << i << "?";
       if (orig_to_norm.find(norm_to_orig[i]) == orig_to_norm.end()) {
-        std::cout << i << "|";
         orig_to_norm[norm_to_orig[i]] = i;
       }
     }
 
-    std::cout << "Text:" << *text << std::endl;
-    std::cout << "Normalized:" << normalized << std::endl;
-
-    std::cout << "Norm to Orig for Denormalization" << std::endl;
-    for(int i = 0; i < norm_to_orig.size(); i++) {
-      std::cout << i << ":" << norm_to_orig[i] << " ";
-    }
-
-    std::cout << std::endl << "Orig2Norm for Denormalization" << std::endl;
-    for(int i = 0; i < norm_to_orig.size(); i++) {
-      if (orig_to_norm.find(i) != orig_to_norm.end())
-        std::cout << i << ":" << orig_to_norm[i] << " ";
-    }
-
     int normalized_piece_surface_index = 0;
     int text_piece_surface_index = 0;
-    std::cout << std::endl;
     // Text is de-normalized, but pieces still need de-normalization.
     int last_consumed_byte = -1;
     for(int i = 0; i < spt->pieces_size(); i++) {
@@ -662,7 +645,6 @@ util::Status SentencePieceProcessor::Decode(
           last_consumed_byte = norm_index->second - 1;
         }
       }
-      std::cout  << "Piece:" << spiece->piece() << "| Surface:" << spiece->surface() << "| NewSurface:" << new_surface << "|" << std::endl;
 
       text_piece_surface_index += curr_surface.size();
 
@@ -672,7 +654,6 @@ util::Status SentencePieceProcessor::Decode(
       spiece->set_end(normalized_piece_surface_index);
     }
   }
-  std::cout << std::endl;
 
   return util::OkStatus();
 }


### PR DESCRIPTION
This PR fixes the SentencePieceText structure returned upon using the C++ APIs. This is particularly relevant in the context of Case Encoding. 

Previously in Encode, the Case Encoding scheme was returning incomplete norm_to_orig mappings which would prevent the code that assigned surfaces to each piece from doing it's job correctly. This PR corrects the norm_to_orig mapping. This fix allows us to ensure that SentencePieceText adheres to the API invariant that `text.substr(piece.begin, piece.end - piece.begin) = piece.surface`

Second, there is a bug in SentencePiece where when it is run with treat_whitespace_as_suffix and add_dummy_prefix together, upon decoding the string, an extra whitespace may be emitted in the text. This PR corrects that.

Lastly, in case of Decode, while SPM assigns the Text parameter in SentencePieceText structure correctly to the "Normalized" (the denormalizer's normalization) form,  it does not correct the piece surfaces with their corresponding fixed indices. The piece surfaces returned currently are still "unnormalized". This is a problem with case encoding since the piece surface strings may have case markers which is not useful generally. This PR corrects the surface strings to match up with the actual Text.