### PR TITLE
Enable toggling Case Encoding flag from C++ Train API

### DIFF
--- a/src/sentencepiece_trainer.cc
+++ b/src/sentencepiece_trainer.cc
@@ -153,6 +153,12 @@ util::Status SentencePieceTrainer::MergeSpecsFromArgs(
       CHECK_OR_RETURN(absl::SimpleAtoi(value, &v));
       absl::SetFlag(&FLAGS_minloglevel, v);
       continue;
+    } else if(key == "encode_unicode_case") {
+      bool b;
+      std::istringstream("true") >> std::boolalpha >> b;
+      normalizer_spec->set_encode_case(b);
+      denormalizer_spec->set_decode_case(b);
+      continue;
     }
 
     const auto status_train = SetProtoField(key, value, trainer_spec);

--- a/src/sentencepiece_trainer.cc
+++ b/src/sentencepiece_trainer.cc
@@ -154,10 +154,10 @@ util::Status SentencePieceTrainer::MergeSpecsFromArgs(
       absl::SetFlag(&FLAGS_minloglevel, v);
       continue;
     } else if(key == "encode_unicode_case") {
-      bool b;
-      std::istringstream("true") >> std::boolalpha >> b;
-      normalizer_spec->set_encode_case(b);
-      denormalizer_spec->set_decode_case(b);
+      bool encode_unicode_case;
+      std::istringstream(value) >> std::boolalpha >> encode_unicode_case;
+      normalizer_spec->set_encode_case(encode_unicode_case);
+      denormalizer_spec->set_decode_case(encode_unicode_case);
       continue;
     }
 


### PR DESCRIPTION
Allow configuring encode_unicode_case flag from within the C++ Training API by fixing up argument parsing.