### PR TITLE
Fix SPM Case Encoding Training C++ API denorm flags

### DIFF
--- a/src/sentencepiece_trainer.cc
+++ b/src/sentencepiece_trainer.cc
@@ -158,6 +158,9 @@ util::Status SentencePieceTrainer::MergeSpecsFromArgs(
       std::istringstream(value) >> std::boolalpha >> encode_unicode_case;
       normalizer_spec->set_encode_case(encode_unicode_case);
       denormalizer_spec->set_decode_case(encode_unicode_case);
+      denormalizer_spec->set_add_dummy_prefix(false);
+      denormalizer_spec->set_remove_extra_whitespaces(false);
+      denormalizer_spec->set_escape_whitespaces(false);
       continue;
     }
 


### PR DESCRIPTION
When Case Encoding is used in C++ Train API based model training, the denormalizer spec must have a few whitespace related flags disabled otherwise the resultant SPM model when trained from the C++ Train API is a) no longer reversible, and b) Inconsistent with spm_train spec.